### PR TITLE
upload name and description to pinata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 environment.env
 example.sql
 
+bin/
+pyvenv.cfg
 
 .idea/*
 

--- a/app/src/controllers/auth_controller.py
+++ b/app/src/controllers/auth_controller.py
@@ -1,5 +1,6 @@
 import string
 import random
+from datetime import timedelta
 
 from fastapi import APIRouter, Depends
 
@@ -52,7 +53,7 @@ def verify_email(
             user.address = account.address
         user.verified = True
         db.commit()
-        access_token = AuthJWT().create_access_token(subject=user.id)
+        access_token = AuthJWT().create_access_token(subject=user.id, expires_time=timedelta(minutes=60))
         return render(user, access_token)
     else:
         return {"message": "Invalid Code"}

--- a/app/src/controllers/media_controller.py
+++ b/app/src/controllers/media_controller.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.src.config.database_config import get_db
 from app.src.config.logger_config import LoggerConfig
+from app.src.models.models import User, Media
 from app.src.services.auth_service import get_current_user_id
 from app.src.requests.create_media_request import CreateMediaRequest, CreateMediaData
 from app.src.services.media_service import MediaService
@@ -28,16 +29,38 @@ def upload_to_ipfs(
     return MediaView(media)
 
 
-@router.put("/{media_id}")
-def update_media(
-        media_id: str,
-        req: CreateMediaRequest,
+@router.get("/recent")
+def get_recent_media(
         db: Session = Depends(get_db),
         user_id: str = Depends(get_current_user_id)
 ):
-    media = MediaService.update(db, media_id, user_id, req.to_data())
+    user = db.query(User).filter(User.id == user_id).first()
+    media = db.query(Media).filter(Media.user == user).order_by(Media.created_at.desc()).first()
     return MediaView(media)
 
+
+@router.get("/{media_id}")
+def get_media_by_id(
+        media_id: str,
+        db: Session = Depends(get_db),
+        user_id: str = Depends(get_current_user_id)
+):
+    media = MediaService.get(db, media_id)
+    if media.user_id != user_id:
+        raise Exception("Unauthorized")
+    return MediaView(media)
+
+#
+# @router.put("/{media_id}")
+# def update_media(
+#         media_id: str,
+#         req: CreateMediaRequest,
+#         db: Session = Depends(get_db),
+#         user_id: str = Depends(get_current_user_id)
+# ):
+#     media = MediaService.update(db, media_id, user_id, req.to_data())
+#     return MediaView(media)
+# 
 
 # Authenticated
 # @router.put("/{media_id}")

--- a/app/src/controllers/mint_controller.py
+++ b/app/src/controllers/mint_controller.py
@@ -19,7 +19,7 @@ def get_media(
         user_id: str = Depends(get_current_user_id)
 ):
     user = db.query(User).filter(User.id == user_id).first()
-    media = db.query(Media).filter(Media.user == user).first()
+    media = db.query(Media).filter(Media.user == user).order_by(Media.created_at.desc()).first()
     ipfs_hash = media.ipfs_hash
     return {'data': ipfs_hash}
 

--- a/app/src/services/media_service.py
+++ b/app/src/services/media_service.py
@@ -1,4 +1,5 @@
 import io
+import json
 import logging
 import uuid
 from typing import Optional
@@ -44,12 +45,21 @@ class MediaService:
         headers = {'Authorization': f'Bearer {Properties.pinata_jwt}'}
         filename = upload_file.filename
         contents = upload_file.file.read()
+        ipfs_metadata = {"name": data.name,
+                         "keyvalues": {
+                             "description": data.description
+                         }}
 
         # TODO - IPFS Metadata using name/description fields
         result = requests.post(url=PIN_URL,
                                files={"file": contents},
-                               data={"pinataOptions": '{"cidVersion":0}'},
+                               data={
+                                   "pinataOptions": '{"cidVersion":0}',
+                                   "pinataMetadata": json.dumps(ipfs_metadata)
+                               },
                                headers=headers)
+
+        logger.info(result.json())
 
         # Also put the file to S3
         s3_key = str(uuid.uuid4())


### PR DESCRIPTION
Sends the name and description to pinata

Also a few other misc changes

In particular, media controller endpoints:
I'd prefer to move away from `/mint/media`
and to `/media/recent`
or more appropriately `/media/:id`
Which at a minimum both return some sort of "mediaView" response
as opposed to just the IPFS hash (but do include it)

None of the changes should mess with existing functionality, so can leave the FE as is for now